### PR TITLE
fix: move backend http settings up one level in hierarchy

### DIFF
--- a/examples/basic-routing/api.tf
+++ b/examples/basic-routing/api.tf
@@ -12,24 +12,6 @@ locals {
           name                = "api-cert"
           key_vault_secret_id = module.kv.certs.api.secret_id
         }
-        backend_http_settings = {
-          main = {
-            port      = 8080
-            protocol  = "Https"
-            host_name = "api.internal"
-            probe = {
-              protocol = "Https"
-              path     = "/health"
-              host     = "api.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           api = {
             fqdns = ["api.internal"]
@@ -40,6 +22,24 @@ locals {
           priority                   = 100
           backend_address_pool_name  = "api"
           backend_http_settings_name = "main"
+        }
+      }
+    }
+    backend_http_settings = {
+      main = {
+        port      = 8080
+        protocol  = "Https"
+        host_name = "api.internal"
+        probe = {
+          protocol = "Https"
+          path     = "/health"
+          host     = "api.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
+          }
         }
       }
     }

--- a/examples/multiple-listeners/catalyst.tf
+++ b/examples/multiple-listeners/catalyst.tf
@@ -11,37 +11,6 @@ locals {
           name                = "global-cert"
           key_vault_secret_id = module.kv.certs.global.secret_id
         }
-        backend_http_settings = {
-          blue = {
-            port      = 8080
-            protocol  = "Https"
-            host_name = "blue.internal"
-            probe = {
-              path     = "/health"
-              host     = "blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-          green = {
-            port      = 8080
-            protocol  = "Https"
-            host_name = "green.internal"
-            probe = {
-              path     = "/health"
-              host     = "green.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             fqdns = ["blue.internal"]
@@ -80,22 +49,6 @@ locals {
         protocol                       = "Http"
         host_name                      = "app.company.eu"
         require_sni                    = false
-        backend_http_settings = {
-          main = {
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              path     = "/health"
-              host     = "eu-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             fqdns = ["eu-blue.internal"]
@@ -128,22 +81,6 @@ locals {
         protocol                       = "Http"
         host_name                      = "app.company.us"
         require_sni                    = false
-        backend_http_settings = {
-          main = {
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              path     = "/health"
-              host     = "asia-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             fqdns = ["us-blue.internal"]
@@ -165,22 +102,6 @@ locals {
         protocol                       = "Http"
         host_name                      = "app.company.as"
         require_sni                    = false
-        backend_http_settings = {
-          main = {
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              path     = "/health"
-              host     = "asia-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             fqdns = ["as-blue.internal"]
@@ -201,22 +122,6 @@ locals {
         protocol                       = "Http"
         host_name                      = "app.company.af"
         require_sni                    = false
-        backend_http_settings = {
-          main = {
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              path     = "/health"
-              host     = "africa-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             fqdns = ["af-blue.internal"]
@@ -238,6 +143,51 @@ locals {
                 rewrite_rule_set_name       = "headers_green"
               }
             }
+          }
+        }
+      }
+    }
+    backend_http_settings = {
+      blue = {
+        port      = 8080
+        protocol  = "Https"
+        host_name = "blue.internal"
+        probe = {
+          path     = "/health"
+          host     = "blue.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
+          }
+        }
+      }
+      green = {
+        port      = 8080
+        protocol  = "Https"
+        host_name = "green.internal"
+        probe = {
+          path     = "/health"
+          host     = "green.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            status_code = ["200-399"]
+          }
+        }
+      }
+      main = {
+        port     = 8080
+        protocol = "Https"
+        probe = {
+          path     = "/health"
+          host     = "eu-blue.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
           }
         }
       }

--- a/examples/nic-associations-backend-pools/mobile.tf
+++ b/examples/nic-associations-backend-pools/mobile.tf
@@ -14,24 +14,6 @@ locals {
           key_vault_secret_id = module.kv.certs.mobile.secret_id
         }
 
-        backend_http_settings = {
-          main = {
-            port      = 443
-            protocol  = "Https"
-            host_name = "mobile.internal"
-            probe = {
-              protocol = "Https"
-              path     = "/health"
-              host     = "mobile.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
-
         backend_address_pools = {
           mobile = {
             name  = "bap-mobile"
@@ -54,6 +36,24 @@ locals {
           priority                   = 100
           backend_address_pool_name  = "bap-mobile"
           backend_http_settings_name = "main"
+        }
+      }
+    }
+
+    backend_http_settings = {
+      main = {
+        port      = 443
+        protocol  = "Https"
+        host_name = "mobile.internal"
+        probe = {
+          protocol = "Https"
+          path     = "/health"
+          host     = "mobile.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            status_code = ["200-399"]
+          }
         }
       }
     }

--- a/examples/nic-associations-backend-pools/vms.tf
+++ b/examples/nic-associations-backend-pools/vms.tf
@@ -30,11 +30,10 @@ locals {
     vm2 = {
       name         = "vm2"
       type         = "windows"
-      size         = "Standard_D4ds_v5"
+      size         = "Standard_D2ds_v5"
       timezone     = "W. Europe Standard Time"
       license_type = "Windows_Server"
       username     = "local-admin"
-      zone         = "1"
       password     = module.kv.secrets.vm2.value
       interfaces = {
         int1 = {

--- a/examples/own-naming/catalyst.tf
+++ b/examples/own-naming/catalyst.tf
@@ -12,41 +12,6 @@ locals {
           name                = "cert-${module.naming.application_gateway.name}-global"
           key_vault_secret_id = module.kv.certs.global.secret_id
         }
-        backend_http_settings = {
-          blue = {
-            name      = "settings-${module.naming.application_gateway.name}-global-blue"
-            port      = 8080
-            protocol  = "Https"
-            host_name = "blue.internal"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-global-blue"
-              path     = "/health"
-              host     = "blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-          green = {
-            name      = "settings-${module.naming.application_gateway.name}-global-green"
-            port      = 8080
-            protocol  = "Https"
-            host_name = "green.internal"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-global-green"
-              path     = "/health"
-              host     = "green.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             name  = "pool-${module.naming.application_gateway.name}-global-blue"
@@ -91,24 +56,6 @@ locals {
         frontend_port_name             = "frontend-port-http"
         protocol                       = "Http"
         host_name                      = "app.company.eu"
-        backend_http_settings = {
-          main = {
-            name     = "settings-${module.naming.application_gateway.name}-europe-main"
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-europe-main"
-              path     = "/health"
-              host     = "eu-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             name  = "pool-${module.naming.application_gateway.name}-europe-blue"
@@ -126,13 +73,13 @@ locals {
           url_path_map = {
             name                               = "map-${module.naming.application_gateway.name}-europe"
             default_backend_address_pool_name  = "pool-${module.naming.application_gateway.name}-europe-blue"
-            default_backend_http_settings_name = "settings-${module.naming.application_gateway.name}-europe-main"
+            default_backend_http_settings_name = "settings-${module.naming.application_gateway.name}-main"
             default_rewrite_rule_set_name      = "headers-${module.naming.application_gateway.name}-blue"
             path_rules = {
               api = {
                 paths                      = ["/api/*"]
                 backend_address_pool_name  = "pool-${module.naming.application_gateway.name}-europe-green"
-                backend_http_settings_name = "settings-${module.naming.application_gateway.name}-europe-main"
+                backend_http_settings_name = "settings-${module.naming.application_gateway.name}-main"
                 rewrite_rule_set_name      = "headers-${module.naming.application_gateway.name}-green"
               }
             }
@@ -145,24 +92,6 @@ locals {
         frontend_port_name             = "frontend-port-http"
         protocol                       = "Http"
         host_name                      = "app.company.usa"
-        backend_http_settings = {
-          main = {
-            name     = "settings-${module.naming.application_gateway.name}-america-main"
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-america-main"
-              path     = "/health"
-              host     = "asia-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             name  = "pool-${module.naming.application_gateway.name}-america-blue"
@@ -177,7 +106,7 @@ locals {
           name                       = "rule-${module.naming.application_gateway.name}-america"
           rule_type                  = "Basic"
           priority                   = 130
-          backend_http_settings_name = "settings-${module.naming.application_gateway.name}-america-main"
+          backend_http_settings_name = "settings-${module.naming.application_gateway.name}-main"
           backend_address_pool_name  = "pool-${module.naming.application_gateway.name}-america-blue"
         }
       }
@@ -187,25 +116,6 @@ locals {
         frontend_port_name             = "frontend-port-http"
         protocol                       = "Http"
         host_name                      = "app.company.asia"
-        backend_http_settings = {
-          main = {
-            name     = "settings-${module.naming.application_gateway.name}-asia-main"
-            name     = "settings-asia-main"
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-asia-main"
-              path     = "/health"
-              host     = "asia-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             name  = "pool-${module.naming.application_gateway.name}-asia-blue"
@@ -229,23 +139,6 @@ locals {
         frontend_port_name             = "frontend-port-http"
         protocol                       = "Http"
         host_name                      = "app.company.af"
-        backend_http_settings = {
-          main = {
-            name     = "settings-${module.naming.application_gateway.name}-africa-main"
-            port     = 8080
-            protocol = "Https"
-            probe = {
-              name     = "probe-${module.naming.application_gateway.name}-africa-main"
-              path     = "/health"
-              host     = "africa-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         backend_address_pools = {
           blue = {
             name  = "pool-${module.naming.application_gateway.name}-africa-blue"
@@ -270,6 +163,57 @@ locals {
                 rewrite_rule_set_name       = "headers-${module.naming.application_gateway.name}-green"
               }
             }
+          }
+        }
+      }
+    }
+    backend_http_settings = {
+      blue = {
+        name      = "settings-${module.naming.application_gateway.name}-global-blue"
+        port      = 8080
+        protocol  = "Https"
+        host_name = "blue.internal"
+        probe = {
+          name     = "probe-${module.naming.application_gateway.name}-global-blue"
+          path     = "/health"
+          host     = "blue.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
+          }
+        }
+      }
+      green = {
+        name      = "settings-${module.naming.application_gateway.name}-global-green"
+        port      = 8080
+        protocol  = "Https"
+        host_name = "green.internal"
+        probe = {
+          name     = "probe-${module.naming.application_gateway.name}-global-green"
+          path     = "/health"
+          host     = "green.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            status_code = ["200-399"]
+          }
+        }
+      }
+      main = {
+        name     = "settings-${module.naming.application_gateway.name}-main"
+        port     = 8080
+        protocol = "Https"
+        probe = {
+          name     = "probe-${module.naming.application_gateway.name}-main"
+          path     = "/health"
+          host     = "main.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
           }
         }
       }

--- a/examples/redirect-routing/website.tf
+++ b/examples/redirect-routing/website.tf
@@ -25,24 +25,6 @@ locals {
 
           }
         }
-        backend_http_settings = {
-          main = {
-            port      = 443
-            protocol  = "Https"
-            host_name = "app.internal"
-            probe = {
-              protocol = "Https"
-              path     = "/health"
-              host     = "app.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         routing_rule = {
           rule_type                  = "Basic"
           priority                   = 100
@@ -64,6 +46,24 @@ locals {
           rule_type                   = "Basic"
           priority                    = 200
           redirect_configuration_name = "to_main"
+        }
+      }
+    }
+    backend_http_settings = {
+      main = {
+        port      = 443
+        protocol  = "Https"
+        host_name = "app.internal"
+        probe = {
+          protocol = "Https"
+          path     = "/health"
+          host     = "app.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
+          }
         }
       }
     }

--- a/examples/rewrite-rules/portal.tf
+++ b/examples/rewrite-rules/portal.tf
@@ -192,23 +192,6 @@ locals {
             fqdns = ["portal-blue.internal"]
           }
         }
-        backend_http_settings = {
-          main = {
-            port      = 8080
-            protocol  = "Https"
-            host_name = "portal-blue.internal"
-            probe = {
-              path     = "/health"
-              host     = "portal-blue.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         routing_rule = {
           rule_type             = "PathBasedRouting"
           priority              = 100
@@ -225,6 +208,23 @@ locals {
                 rewrite_rule_set_name      = "api"
               }
             }
+          }
+        }
+      }
+    }
+    backend_http_settings = {
+      main = {
+        port      = 8080
+        protocol  = "Https"
+        host_name = "portal-blue.internal"
+        probe = {
+          path     = "/health"
+          host     = "portal-blue.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
           }
         }
       }

--- a/examples/waf-policy/webapp.tf
+++ b/examples/waf-policy/webapp.tf
@@ -17,29 +17,29 @@ locals {
             fqdns = ["app.internal"]
           }
         }
-        backend_http_settings = {
-          main = {
-            port      = 8080
-            protocol  = "Https"
-            host_name = "app.internal"
-            probe = {
-              protocol = "Https"
-              path     = "/health"
-              host     = "app.internal"
-              interval = 30
-              timeout  = 30
-              match = {
-                body        = null
-                status_code = ["200-399"]
-              }
-            }
-          }
-        }
         routing_rule = {
           rule_type                  = "Basic"
           priority                   = 100
           backend_address_pool_name  = "primary"
           backend_http_settings_name = "main"
+        }
+      }
+    }
+    backend_http_settings = {
+      main = {
+        port      = 8080
+        protocol  = "Https"
+        host_name = "app.internal"
+        probe = {
+          protocol = "Https"
+          path     = "/health"
+          host     = "app.internal"
+          interval = 30
+          timeout  = 30
+          match = {
+            body        = null
+            status_code = ["200-399"]
+          }
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -84,12 +84,14 @@ resource "azurerm_application_gateway" "application_gateway" {
         for listener_key, listener in app.listeners :
         {
           name                = listener.certificate.name
-          key_vault_secret_id = listener.certificate.key_vault_secret_id
+          key_vault_secret_id = try(listener.certificate.key_vault_secret_id, null)
+          data                = try(listener.certificate.data, null)
+          password            = try(listener.certificate.password, null)
     } if try(listener.certificate, null) != null]]))
 
     content {
       name                = ssl_certificate.value.name
-      key_vault_secret_id = ssl_certificate.value.key_vault_secret_id
+      key_vault_secret_id = try(ssl_certificate.value.key_vault_secret_id, null)
       data                = try(ssl_certificate.value.data, null)
       password            = try(ssl_certificate.value.password, null)
     }


### PR DESCRIPTION
## Description

Moved the backend_http_settings to a higher level in the data structure, updated the examples accordingly. 

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything)

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #0000
