### PR TITLE
feat: add http2_enabled, backend, listener, routing_rule and missing probe/ssl_profile attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ object({
     force_firewall_policy_association = optional(bool, false)
     fips_enabled                      = optional(bool, false)
     enable_http2                      = optional(bool, false)
+    http2_enabled                     = optional(bool, false)
     zones                             = optional(list(string), [])
     tags                              = optional(map(string))
     sku = object({
@@ -205,6 +206,7 @@ object({
           minimum_servers                           = optional(number)
           unhealthy_threshold                       = optional(number, 3)
           pick_host_name_from_backend_http_settings = optional(bool, false)
+          proxy_protocol_header_enabled             = optional(bool)
           match = optional(object({
             status_code = list(string)
             body        = optional(string)
@@ -262,6 +264,7 @@ object({
       name                                 = string
       trusted_client_certificate_names     = list(string)
       verify_client_cert_issuer_dn         = optional(bool, false)
+      verify_client_certificate_issuer_dn  = optional(bool)
       verify_client_certificate_revocation = optional(string)
       ssl_policy = optional(object({
         policy_type          = optional(string, "Predefined")
@@ -305,6 +308,32 @@ object({
     trusted_client_certificate = optional(map(object({
       name = string
       data = string
+    })), {})
+    backend = optional(map(object({
+      name                           = optional(string)
+      port                           = number
+      protocol                       = string
+      host_name                      = optional(string)
+      probe_name                     = optional(string)
+      timeout_in_seconds             = optional(number)
+      trusted_root_certificate_names = optional(list(string), [])
+      client_ip_preservation_enabled = optional(bool)
+    })), {})
+    listener = optional(map(object({
+      name                           = optional(string)
+      frontend_ip_configuration_name = string
+      frontend_port_name             = string
+      protocol                       = string
+      host_names                     = optional(set(string))
+      ssl_certificate_name           = optional(string)
+      ssl_profile_name               = optional(string)
+    })), {})
+    routing_rule = optional(map(object({
+      name                      = optional(string)
+      backend_address_pool_name = string
+      backend_name              = string
+      listener_name             = string
+      priority                  = number
     })), {})
   })
 ```

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_application_gateway" "this" {
   force_firewall_policy_association = var.config.force_firewall_policy_association
   fips_enabled                      = var.config.fips_enabled
   enable_http2                      = var.config.enable_http2
+  http2_enabled                     = var.config.http2_enabled
   zones                             = var.config.zones
 
   tags = coalesce(
@@ -260,6 +261,7 @@ resource "azurerm_application_gateway" "this" {
           minimum_servers                           = setting.probe.minimum_servers
           pick_host_name_from_backend_http_settings = setting.probe.pick_host_name_from_backend_http_settings
           unhealthy_threshold                       = setting.probe.unhealthy_threshold
+          proxy_protocol_header_enabled             = setting.probe.proxy_protocol_header_enabled
         } if setting.probe != null
       ]
     ])
@@ -275,6 +277,7 @@ resource "azurerm_application_gateway" "this" {
       minimum_servers                           = probe.value.minimum_servers
       unhealthy_threshold                       = probe.value.unhealthy_threshold
       pick_host_name_from_backend_http_settings = probe.value.pick_host_name_from_backend_http_settings
+      proxy_protocol_header_enabled             = probe.value.proxy_protocol_header_enabled
 
       dynamic "match" {
         for_each = probe.value.match_status_codes != null ? [1] : []
@@ -501,6 +504,7 @@ resource "azurerm_application_gateway" "this" {
       name                                 = ssl_profile.value.name
       trusted_client_certificate_names     = ssl_profile.value.trusted_client_certificate_names
       verify_client_cert_issuer_dn         = ssl_profile.value.verify_client_cert_issuer_dn
+      verify_client_certificate_issuer_dn  = ssl_profile.value.verify_client_certificate_issuer_dn
       verify_client_certificate_revocation = ssl_profile.value.verify_client_certificate_revocation
 
       dynamic "ssl_policy" {
@@ -584,6 +588,47 @@ resource "azurerm_application_gateway" "this" {
     content {
       name = trusted_client_certificate.value.name
       data = trusted_client_certificate.value.data
+    }
+  }
+
+  dynamic "backend" {
+    for_each = var.config.backend
+
+    content {
+      name                           = coalesce(backend.value.name, backend.key)
+      port                           = backend.value.port
+      protocol                       = backend.value.protocol
+      host_name                      = backend.value.host_name
+      probe_name                     = backend.value.probe_name
+      timeout_in_seconds             = backend.value.timeout_in_seconds
+      trusted_root_certificate_names = backend.value.trusted_root_certificate_names
+      client_ip_preservation_enabled = backend.value.client_ip_preservation_enabled
+    }
+  }
+
+  dynamic "listener" {
+    for_each = var.config.listener
+
+    content {
+      name                           = coalesce(listener.value.name, listener.key)
+      frontend_ip_configuration_name = listener.value.frontend_ip_configuration_name
+      frontend_port_name             = listener.value.frontend_port_name
+      protocol                       = listener.value.protocol
+      host_names                     = listener.value.host_names
+      ssl_certificate_name           = listener.value.ssl_certificate_name
+      ssl_profile_name               = listener.value.ssl_profile_name
+    }
+  }
+
+  dynamic "routing_rule" {
+    for_each = var.config.routing_rule
+
+    content {
+      name                      = coalesce(routing_rule.value.name, routing_rule.key)
+      backend_address_pool_name = routing_rule.value.backend_address_pool_name
+      backend_name              = routing_rule.value.backend_name
+      listener_name             = routing_rule.value.listener_name
+      priority                  = routing_rule.value.priority
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,7 @@ variable "config" {
     force_firewall_policy_association = optional(bool, false)
     fips_enabled                      = optional(bool, false)
     enable_http2                      = optional(bool, false)
+    http2_enabled                     = optional(bool, false)
     zones                             = optional(list(string), [])
     tags                              = optional(map(string))
     sku = object({
@@ -147,6 +148,7 @@ variable "config" {
           minimum_servers                           = optional(number)
           unhealthy_threshold                       = optional(number, 3)
           pick_host_name_from_backend_http_settings = optional(bool, false)
+          proxy_protocol_header_enabled             = optional(bool)
           match = optional(object({
             status_code = list(string)
             body        = optional(string)
@@ -204,6 +206,7 @@ variable "config" {
       name                                 = string
       trusted_client_certificate_names     = list(string)
       verify_client_cert_issuer_dn         = optional(bool, false)
+      verify_client_certificate_issuer_dn  = optional(bool)
       verify_client_certificate_revocation = optional(string)
       ssl_policy = optional(object({
         policy_type          = optional(string, "Predefined")
@@ -247,6 +250,32 @@ variable "config" {
     trusted_client_certificate = optional(map(object({
       name = string
       data = string
+    })), {})
+    backend = optional(map(object({
+      name                           = optional(string)
+      port                           = number
+      protocol                       = string
+      host_name                      = optional(string)
+      probe_name                     = optional(string)
+      timeout_in_seconds             = optional(number)
+      trusted_root_certificate_names = optional(list(string), [])
+      client_ip_preservation_enabled = optional(bool)
+    })), {})
+    listener = optional(map(object({
+      name                           = optional(string)
+      frontend_ip_configuration_name = string
+      frontend_port_name             = string
+      protocol                       = string
+      host_names                     = optional(set(string))
+      ssl_certificate_name           = optional(string)
+      ssl_profile_name               = optional(string)
+    })), {})
+    routing_rule = optional(map(object({
+      name                      = optional(string)
+      backend_address_pool_name = string
+      backend_name              = string
+      listener_name             = string
+      priority                  = number
     })), {})
   })
 


### PR DESCRIPTION
closes #62

## Summary
Adds the six missing optional schema surface points reported by generated schema validation against `azurerm_application_gateway`. The deprecated counterparts (`enable_http2`, `backend_address_pool`/`request_routing_rule`/`http_listener`, `verify_client_cert_issuer_dn`) are left untouched per the issue's out-of-scope rule.

- Root: `http2_enabled`, `backend`, `listener`, `routing_rule`
- `probe`: `proxy_protocol_header_enabled`
- `ssl_profile`: `verify_client_certificate_issuer_dn`

New collections are exposed as `optional(map(object({...})), {})` with `coalesce(value.name, key)` naming, matching the existing module pattern (`private_link_configuration`, `ssl_profile`).

## Verification
- azurerm_application_gateway.http2_enabled                                forces_new=no  → feat:
- azurerm_application_gateway.backend                                      forces_new=no  → feat:
- azurerm_application_gateway.routing_rule                                 forces_new=no  → feat:
- azurerm_application_gateway.probe.proxy_protocol_header_enabled          forces_new=no  → feat:
- azurerm_application_gateway.ssl_profile.verify_client_certificate_issuer_dn  forces_new=no  → feat:
- azurerm_application_gateway.listener                                     forces_new=no  → feat:

Commit: `feat:` (no touched argument has forces_new == true)