### PR TITLE
fix: remove default "/" from backend_http_settings path to  preserve request paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ object({
         host_name                            = optional(string)
         cookie_based_affinity                = optional(string, "Disabled")
         request_timeout                      = optional(number, 30)
-        path                                 = optional(string, "/")
+        path                                 = optional(string)
         pick_host_name_from_backend_address  = optional(bool, false)
         affinity_cookie_name                 = optional(string)
         trusted_root_certificate_names       = optional(list(string), [])

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "config" {
         host_name                            = optional(string)
         cookie_based_affinity                = optional(string, "Disabled")
         request_timeout                      = optional(number, 30)
-        path                                 = optional(string, "/")
+        path                                 = optional(string)
         pick_host_name_from_backend_address  = optional(bool, false)
         affinity_cookie_name                 = optional(string)
         trusted_root_certificate_names       = optional(list(string), [])


### PR DESCRIPTION
## Description

backend_http_settings.path was defined as optional(string, "/"), which silently overrides all backend request paths to / for any caller that omits the field. This breaks path-based routing — sub-paths like /api/v1/users are rewritten to / before reaching the backend.                                                                                                                        
                       
The fix removes the default so the field behaves as a true optional: when omitted or set to null, no path override is sent to Azure and original request paths are preserved end-to-end.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything)

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_application_gateway` - fix `backend_http_settings.path` default "/" that silently overrode all backend request paths when the field was omitted


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #84 
